### PR TITLE
Start Astro prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Erm, I mean - to get a professional presence out on the web.
 <br/><br/>
 
 site powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte)
+
+## Astro prototype
+
+A new `astro` directory contains an early experiment using [Astro](https://astro.build) with the Preact integration. Run `npm install` inside that folder and `npm run dev` to start the dev server.

--- a/astro/README.md
+++ b/astro/README.md
@@ -1,0 +1,16 @@
+# Astro + Preact prototype
+
+This directory contains a minimal [Astro](https://astro.build) project using the Preact integration.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Building
+
+```bash
+npm run build
+```

--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import preact from '@astrojs/preact';
+
+export default defineConfig({
+  integrations: [preact()],
+  output: 'static'
+});

--- a/astro/package.json
+++ b/astro/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "astro-site",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/preact": "^3.0.0",
+    "preact": "^10.19.0"
+  }
+}

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,0 +1,12 @@
+---
+import { h } from 'preact';
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Astro Preact Starter</title>
+  </head>
+  <body>
+    <h1>Hello from Astro + Preact!</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Astro project skeleton using Preact
- mention new Astro prototype in README

## Testing
- `npm install` *(passes)*
- `npm test` *(fails: browsers missing)*
- `npx playwright install --with-deps` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_687b6af169b08331b374c042c7c7b460