### PR TITLE
Expand Astro prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Erm, I mean - to get a professional presence out on the web.
 <br/><br/>
 
 site powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte)
+
+## Astro prototype
+
+A new `astro` directory contains an early experiment using [Astro](https://astro.build) with the Preact integration. Run `npm install` inside that folder and `npm run dev` to start the dev server.
+The prototype now includes a Preact profile component and simple `/about` and `/skills` pages.

--- a/astro/README.md
+++ b/astro/README.md
@@ -1,0 +1,24 @@
+# Astro + Preact prototype
+
+This directory contains an early experiment for rebuilding the site with [Astro](https://astro.build) and the Preact integration.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Navigate to `http://localhost:4321` after running the dev server.
+
+## Building
+
+```bash
+npm run build
+```
+
+## Pages
+
+- `/` - profile and quick links
+- `/about` - about me section
+- `/skills` - list of technical and non‑technical skills

--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import preact from '@astrojs/preact';
+
+export default defineConfig({
+  integrations: [preact()],
+  output: 'static'
+});

--- a/astro/package.json
+++ b/astro/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "astro-site",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/preact": "^3.0.0",
+    "preact": "^10.19.0"
+  }
+}

--- a/astro/src/components/Profile.tsx
+++ b/astro/src/components/Profile.tsx
@@ -1,0 +1,16 @@
+import { h } from 'preact';
+
+export default function Profile() {
+  return (
+    <div>
+      <h1>Brad Deibert</h1>
+      <p>Software Engineer based in Missoula, MT.</p>
+      <p>Interests: React, TypeScript, Go.</p>
+      <p>
+        <a href="https://github.com/braddeibert" target="_blank" rel="noopener noreferrer">GitHub</a>
+        {" | "}
+        <a href="https://www.linkedin.com/in/bradleydeibert/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      </p>
+    </div>
+  );
+}

--- a/astro/src/pages/about.astro
+++ b/astro/src/pages/about.astro
@@ -1,0 +1,22 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>About Brad Deibert</title>
+  </head>
+  <body>
+    <h1>About Me</h1>
+    <h2>I am:</h2>
+    <ul>
+      <li>Originally from northwest Montana near Glacier National Park.</li>
+      <li>Married to Alicia since August 2020.</li>
+    </ul>
+    <h2>I enjoy:</h2>
+    <ul>
+      <li>Lifting weights and staying active.</li>
+      <li>Getting outdoors - biking, fishing, golfing.</li>
+      <li>Podcasts and books when I can find the time.</li>
+    </ul>
+  </body>
+</html>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,0 +1,16 @@
+---
+import Profile from '../components/Profile.tsx';
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Brad Deibert</title>
+  </head>
+  <body>
+    <Profile />
+    <nav>
+      <a href="/about">About</a> |
+      <a href="/skills">Skillset</a>
+    </nav>
+  </body>
+</html>

--- a/astro/src/pages/skills.astro
+++ b/astro/src/pages/skills.astro
@@ -1,0 +1,28 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Skillset</title>
+  </head>
+  <body>
+    <h1>Skillset</h1>
+    <h2>Technical skills:</h2>
+    <ul>
+      <li>React & Redux</li>
+      <li>HTML, CSS, JavaScript</li>
+      <li>Other tools - git and command line</li>
+    </ul>
+    <p>I'm also familiar with:</p>
+    <ul>
+      <li>Python APIs like Flask and Django</li>
+      <li>Java - my first programming language</li>
+    </ul>
+    <h2>Non-technical skills:</h2>
+    <ul>
+      <li>Comfortable working in fast-paced environments</li>
+      <li>Thrive in collaborative teams</li>
+      <li>Eager to learn and grow</li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- expand Astro project with Preact profile component and index page
- add `/about` and `/skills` pages with personal info
- document new pages in the Astro README and root README

## Testing
- `npm install`
- `npm test` *(fails: browsers missing)*
- `npx playwright install --with-deps` *(fails: packages unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687b6af169b08331b374c042c7c7b460