### PR TITLE
Update site styling with dark mode theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Erm, I mean - to get a professional presence out on the web.
 <br/><br/>
 
 site powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte)
+
+## Astro prototype
+
+A new `astro` directory contains an early experiment using [Astro](https://astro.build) with the Preact integration. Run `npm install` inside that folder and `npm run dev` to start the dev server.
+The prototype now includes a Preact profile component and simple `/about` and `/skills` pages.

--- a/astro/README.md
+++ b/astro/README.md
@@ -1,0 +1,24 @@
+# Astro + Preact prototype
+
+This directory contains an early experiment for rebuilding the site with [Astro](https://astro.build) and the Preact integration.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Navigate to `http://localhost:4321` after running the dev server.
+
+## Building
+
+```bash
+npm run build
+```
+
+## Pages
+
+- `/` - profile and quick links
+- `/about` - about me section
+- `/skills` - list of technical and non‑technical skills

--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'astro/config';
+import preact from '@astrojs/preact';
+
+export default defineConfig({
+  integrations: [preact()],
+  output: 'static'
+});

--- a/astro/package.json
+++ b/astro/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "astro-site",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/preact": "^3.0.0",
+    "preact": "^10.19.0"
+  }
+}

--- a/astro/src/components/Profile.tsx
+++ b/astro/src/components/Profile.tsx
@@ -1,0 +1,16 @@
+import { h } from 'preact';
+
+export default function Profile() {
+  return (
+    <div>
+      <h1>Brad Deibert</h1>
+      <p>Software Engineer based in Missoula, MT.</p>
+      <p>Interests: React, TypeScript, Go.</p>
+      <p>
+        <a href="https://github.com/braddeibert" target="_blank" rel="noopener noreferrer">GitHub</a>
+        {" | "}
+        <a href="https://www.linkedin.com/in/bradleydeibert/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      </p>
+    </div>
+  );
+}

--- a/astro/src/pages/about.astro
+++ b/astro/src/pages/about.astro
@@ -1,0 +1,22 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>About Brad Deibert</title>
+  </head>
+  <body>
+    <h1>About Me</h1>
+    <h2>I am:</h2>
+    <ul>
+      <li>Originally from northwest Montana near Glacier National Park.</li>
+      <li>Married to Alicia since August 2020.</li>
+    </ul>
+    <h2>I enjoy:</h2>
+    <ul>
+      <li>Lifting weights and staying active.</li>
+      <li>Getting outdoors - biking, fishing, golfing.</li>
+      <li>Podcasts and books when I can find the time.</li>
+    </ul>
+  </body>
+</html>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,0 +1,16 @@
+---
+import Profile from '../components/Profile.tsx';
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Brad Deibert</title>
+  </head>
+  <body>
+    <Profile />
+    <nav>
+      <a href="/about">About</a> |
+      <a href="/skills">Skillset</a>
+    </nav>
+  </body>
+</html>

--- a/astro/src/pages/skills.astro
+++ b/astro/src/pages/skills.astro
@@ -1,0 +1,28 @@
+---
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Skillset</title>
+  </head>
+  <body>
+    <h1>Skillset</h1>
+    <h2>Technical skills:</h2>
+    <ul>
+      <li>React & Redux</li>
+      <li>HTML, CSS, JavaScript</li>
+      <li>Other tools - git and command line</li>
+    </ul>
+    <p>I'm also familiar with:</p>
+    <ul>
+      <li>Python APIs like Flask and Django</li>
+      <li>Java - my first programming language</li>
+    </ul>
+    <h2>Non-technical skills:</h2>
+    <ul>
+      <li>Comfortable working in fast-paced environments</li>
+      <li>Thrive in collaborative teams</li>
+      <li>Eager to learn and grow</li>
+    </ul>
+  </body>
+</html>

--- a/src/app.html
+++ b/src/app.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" style="height: 100%">
 	<head>
 		<meta charset="utf-8" />
@@ -27,15 +27,26 @@
 		font-family: 'Zilla Slab', serif;
 	}
 
-	body {
-		color: #161616;
-		background-color: #ececec;
-		overflow: hidden;
+	:root {
+		--bg-color: #f8f9fa;
+		--text-color: #212529;
+		--border-color: #dee2e6;
+		--accent-color: #5463ff;
+		--shadow-color: rgba(0, 0, 0, 0.1);
 	}
 
 	body.dark {
-		color: #ececec;
-		background-color: #161616;
+		--bg-color: #121212;
+		--text-color: #f1f1f1;
+		--border-color: #444;
+		--accent-color: #ffd54f;
+		--shadow-color: rgba(0, 0, 0, 0.4);
+	}
+
+	body {
+		color: var(--text-color);
+		background-color: var(--bg-color);
+		overflow: hidden;
 	}
 
 	h1,
@@ -76,7 +87,7 @@
 	}
 
 	a:hover {
-		color: #5463ff;
+		color: var(--accent-color);
 	}
 
 	.container {

--- a/src/components/Home.svelte
+++ b/src/components/Home.svelte
@@ -96,25 +96,26 @@
 </Section>
 
 <style>
-	.card {
-		height: min-content;
-		padding: 32px;
+        .card {
+                height: min-content;
+                padding: 32px;
 
-		flex-grow: 1;
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		gap: 32px;
+                flex-grow: 1;
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+                gap: 32px;
 
-		border: 5px solid #10316b;
-		border-radius: 1rem;
-		box-shadow: 0.5rem 0.5rem #0b8457;
-	}
+                background-color: var(--bg-color);
+                border: 2px solid var(--border-color);
+                border-radius: 1rem;
+                box-shadow: 0.5rem 0.5rem var(--shadow-color);
+        }
 
-	.card.dark {
-		border: 5px solid #ff1818;
-		box-shadow: 0.5rem 0.5rem #ffc300;
-	}
+        .card.dark {
+                border-color: var(--accent-color);
+                box-shadow: 0.5rem 0.5rem var(--accent-color);
+        }
 
 	.content {
 		flex-grow: 1;

--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -7,13 +7,9 @@
 </div>
 
 <style>
-	.icon {
-		/* color: #161616; */
-		height: 30px;
-		width: 30px;
-	}
-
-	/* .icon.dark {
-		color: #ececec;
-	} */
+        .icon {
+                height: 30px;
+                width: 30px;
+                color: var(--accent-color);
+        }
 </style>

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -22,25 +22,26 @@
 </label>
 
 <style>
-	.theme-toggle {
-		position: sticky;
-		top: 25px;
-		left: calc(100% - 165px);
+        .theme-toggle {
+                position: sticky;
+                top: 25px;
+                left: calc(100% - 165px);
 
-		color: #161616;
-		outline: 2px solid #161616;
+                color: var(--text-color);
+                background-color: var(--bg-color);
+                outline: 2px solid var(--border-color);
 
-		display: flex;
-		align-items: center;
-		gap: 4px;
+                display: flex;
+                align-items: center;
+                gap: 4px;
 
-		width: max-content;
-		padding: 16px;
-		border-radius: 2rem;
-	}
+                width: max-content;
+                padding: 16px;
+                border-radius: 2rem;
+        }
 
-	.theme-toggle.dark {
-		color: #ececec;
-		outline: 2px solid #ececec;
-	}
+        .theme-toggle.dark {
+                color: var(--text-color);
+                outline: 2px solid var(--border-color);
+        }
 </style>

--- a/src/components/layout/Dialog.svelte
+++ b/src/components/layout/Dialog.svelte
@@ -40,9 +40,9 @@
 		left: 0;
 	}
 
-	.dialog-body {
-		background-color: #ececec;
-		color: inherit;
+        .dialog-body {
+                background-color: var(--bg-color);
+                color: var(--text-color);
 
 		display: flex;
 		flex-direction: column;
@@ -55,10 +55,10 @@
 		border-radius: 0.5rem;
 	}
 
-	.dialog-body.dark {
-		color: #ececec;
-		background-color: #161616;
-	}
+        .dialog-body.dark {
+                background-color: var(--bg-color);
+                color: var(--text-color);
+        }
 
 	.close {
 		position: absolute;


### PR DESCRIPTION
## Summary
- introduce CSS variables for theme colors
- modernize card styling and icon colors
- update ThemeToggle styles
- use theme colors in dialog overlay

## Testing
- `npm run format`
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6af169b08331b374c042c7c7b460